### PR TITLE
docs: call out --noauth_local_webserver in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ and place it in a user accessible directory.
 By default gmail-relay.py will look in `~/.gmail-relay/client_secret.json`, but if you use a different 
 directory you can pass the --config=myconfigdir argument.
 
+If you aren't running on a system with a browser, pass `--noauth_local_webserver`.
+
 gmail-relay.py depends on `google-api-python-client` so first make sure you have that installed.
 
 Then, run:

--- a/gmail-relay.py
+++ b/gmail-relay.py
@@ -13,7 +13,7 @@ import sys
 
 try:
     import argparse
-    parser = argparse.ArgumentParser(parents=[tools.argparser])
+    parser = argparse.ArgumentParser(parents=[tools.argparser]) # this adds flags from oauth2client tools
     parser.add_argument("--auth", help="Perform auth and exit", action="store_true")
     parser.add_argument("--config", help="Directory to read and write config files from",
                         type=str, default=os.path.join(os.path.expanduser('~'), ".gmail-relay"))


### PR DESCRIPTION
I didn't run `./gmail-relay.py --help` cause I just read the file, so I was looking at the docs for oauth2client before I found that option and eventually figured out how stuff worked.